### PR TITLE
Refactor: HomeFragment와 BookmarkFragment 사이의 원활한 데이터 공유를 위해 뷰모델 적용

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,13 @@ android {
 
 dependencies {
 
+    // ViewModel
+    def lifecycle_version = "2.5.0-alpha06"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"  // viewModel
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"   // liveData
+    implementation 'androidx.activity:activity-ktx:1.4.0'   // by viewModels()
+    implementation 'androidx.fragment:fragment-ktx:1.4.1'   // by activityViewModels()
+
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.3.1'
     implementation 'androidx.core:core-ktx:1.7.0'

--- a/app/src/main/java/com/example/snack4diet/MainActivity.kt
+++ b/app/src/main/java/com/example/snack4diet/MainActivity.kt
@@ -10,14 +10,14 @@ import com.example.snack4diet.viewModel.NutrientsViewModel
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
-    private lateinit var nutrients: NutrientsViewModel
+    private lateinit var viewModel: NutrientsViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        nutrients = ViewModelProvider(this).get(NutrientsViewModel::class.java)
+        viewModel = ViewModelProvider(this).get(NutrientsViewModel::class.java)
 
         setHomeFragment()
     }
@@ -33,5 +33,9 @@ class MainActivity : AppCompatActivity() {
             .replace(R.id.mainFrame, fragment, tag)
             .addToBackStack(null) // 이전 프래그먼트를 백스택에 추가
             .commit()
+    }
+
+    fun getViewModel(): NutrientsViewModel {
+        return viewModel
     }
 }

--- a/app/src/main/java/com/example/snack4diet/api/ApiModels.kt
+++ b/app/src/main/java/com/example/snack4diet/api/ApiModels.kt
@@ -21,4 +21,3 @@ data class NutritionItem(
     val consumedAmount: Int,
     val targetAmount: Int
 )
-

--- a/app/src/main/java/com/example/snack4diet/bookmark/BookmarkAdapter.kt
+++ b/app/src/main/java/com/example/snack4diet/bookmark/BookmarkAdapter.kt
@@ -1,0 +1,50 @@
+package com.example.snack4diet.bookmark
+
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.snack4diet.api.Macronutrients
+import com.example.snack4diet.databinding.ItemBookmarkBinding
+
+class BookmarkAdapter(
+    var nutrients: List<Macronutrients>,
+    private val onDeleteListener: (Macronutrients) -> Unit
+    ): RecyclerView.Adapter<BookmarkAdapter.ViewHolder> () {
+
+    inner class ViewHolder(binding: ItemBookmarkBinding): RecyclerView.ViewHolder(binding.root) {
+        val foodName = binding.foodName
+        val kcal = binding.kcal
+        val protein = binding.protein
+        val province = binding.province
+        val carbohydrate = binding.carbohydrate
+        val btnEdit = binding.btnEdit
+        val btnDelete = binding.btnDelete
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemBookmarkBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = nutrients[position]
+
+        holder.foodName.text = item.foodName
+        holder.kcal.text = item.kcal.toString() + "kcal"
+        holder.protein.text = item.protein.toString() + "g"
+        holder.province.text = item.province.toString() + "g"
+        holder.carbohydrate.text = item.carbohydrate.toString() + "g"
+        holder.itemView.visibility = View.VISIBLE
+
+        holder.btnDelete.setOnClickListener {
+            onDeleteListener(item)
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return nutrients.size
+    }
+}

--- a/app/src/main/java/com/example/snack4diet/bookmark/BookmarkFragment.kt
+++ b/app/src/main/java/com/example/snack4diet/bookmark/BookmarkFragment.kt
@@ -5,10 +5,17 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.snack4diet.MainActivity
+import com.example.snack4diet.api.Macronutrients
 import com.example.snack4diet.databinding.FragmentBookmarkBinding
+import com.example.snack4diet.viewModel.NutrientsViewModel
 
 class BookmarkFragment : Fragment() {
     private lateinit var binding: FragmentBookmarkBinding
+    private lateinit var viewModel: NutrientsViewModel
+    private lateinit var bookmarkAdapter: BookmarkAdapter
+    private lateinit var bookmarkList: MutableList<Macronutrients>
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -22,6 +29,28 @@ class BookmarkFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        //뷰모델 초기화
+        viewModel = (requireActivity() as MainActivity).getViewModel()
+        bookmarkList = mutableListOf()
 
+        //리사이클러뷰 어댑터 설정
+        bookmarkAdapter = BookmarkAdapter(emptyList()) { nutrient ->
+            viewModel.deleteBookmark(nutrient)
+            bookmarkAdapter.notifyDataSetChanged()
+        }
+
+        binding.recyclerView.adapter = bookmarkAdapter
+        binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
+
+        viewModel.nutrientsLiveData.observe(requireActivity()) { nutrients ->
+
+            for (nutrient in nutrients) {
+                if (nutrient.isBookmark) {
+                    bookmarkList.add(nutrient)
+                }
+            }
+            bookmarkAdapter.nutrients = bookmarkList
+            bookmarkAdapter.notifyDataSetChanged()
+        }
     }
 }

--- a/app/src/main/java/com/example/snack4diet/home/DiaryAdapter.kt
+++ b/app/src/main/java/com/example/snack4diet/home/DiaryAdapter.kt
@@ -3,12 +3,13 @@ package com.example.snack4diet.home
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.AdapterView.OnItemClickListener
 import androidx.recyclerview.widget.RecyclerView
 import com.example.snack4diet.R
 import com.example.snack4diet.api.Macronutrients
 import com.example.snack4diet.databinding.ItemDiaryBinding
 
-class DiaryAdapter(private val nutrients: List<Macronutrients>): RecyclerView.Adapter<DiaryAdapter.ViewHolder> () {
+class DiaryAdapter( var nutrients: List<Macronutrients>, private val itemClickListener: (Macronutrients) -> Unit): RecyclerView.Adapter<DiaryAdapter.ViewHolder> () {
     private var onItemClickCallback: ((Int) -> Unit)? = null
 
     fun setOnItemClickListener(callback: (Int) -> Unit) {
@@ -54,10 +55,7 @@ class DiaryAdapter(private val nutrients: List<Macronutrients>): RecyclerView.Ad
         }
 
         holder.btnBookmark.setOnClickListener {
-            if (!item.isBookmark) {
-                holder.btnBookmark.setImageResource(R.drawable.ic_filled_star)
-                item.isBookmark = true
-            }
+            itemClickListener(item)
         }
     }
 

--- a/app/src/main/java/com/example/snack4diet/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/snack4diet/home/HomeFragment.kt
@@ -12,6 +12,10 @@ import android.view.ViewGroup
 import android.widget.Button
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment.STYLE_NORMAL
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.snack4diet.MainActivity
 import com.example.snack4diet.R
@@ -19,6 +23,7 @@ import com.example.snack4diet.api.Macronutrients
 import com.example.snack4diet.api.NutritionItem
 import com.example.snack4diet.bookmark.BookmarkFragment
 import com.example.snack4diet.databinding.FragmentHomeBinding
+import com.example.snack4diet.viewModel.NutrientsViewModel
 import java.time.DayOfWeek
 import java.time.LocalDate
 
@@ -28,7 +33,7 @@ class HomeFragment : Fragment() {
     private lateinit var homeAdapter: HomeAdapter
     private lateinit var dailyNutrition: List<NutritionItem>
     private lateinit var diaryAdapter: DiaryAdapter
-    private lateinit var nutrients: List<Macronutrients>
+    private lateinit var viewModel: NutrientsViewModel
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -41,6 +46,8 @@ class HomeFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        viewModel = (requireActivity() as MainActivity).getViewModel()
 
         val today = LocalDate.now()
         var dayOfWeek = today.dayOfWeek.toString()
@@ -64,13 +71,6 @@ class HomeFragment : Fragment() {
             NutritionItem("carbohydrate", 243, 324),
             NutritionItem("protein", 16, 64,),
             NutritionItem("province", 52, 51)
-        )
-
-        nutrients = listOf(
-            Macronutrients("음식1",325, 24,32,25, false),
-            Macronutrients("음식2",325, 24,32,25, false),
-            Macronutrients("음식3",325, 24,32,25, false),
-            Macronutrients("음식4",325, 24,32,25, false)
         )
 
         if (dailyNutrition == null) {
@@ -107,7 +107,10 @@ class HomeFragment : Fragment() {
 
     private fun setDiaryRecyclerView() {
         //리사이클러뷰 설정
-        diaryAdapter = DiaryAdapter(nutrients)
+        diaryAdapter = DiaryAdapter(emptyList()) { nutrient ->
+            viewModel.resisterBookmark(nutrient)
+            diaryAdapter.notifyDataSetChanged()
+        }
         binding.recyclerView.adapter = diaryAdapter
         binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
         //클릭되지 않은 버튼 처리
@@ -126,6 +129,11 @@ class HomeFragment : Fragment() {
             bottomSheetFragment.arguments = bundle
             bottomSheetFragment.setStyle(STYLE_NORMAL, R.style.DialogCustomTheme)
             bottomSheetFragment.show(childFragmentManager, bottomSheetFragment.tag)
+        }
+
+        viewModel.nutrientsLiveData.observe(requireActivity()) { nutrientsLiveData ->
+            diaryAdapter.nutrients = nutrientsLiveData
+            diaryAdapter.notifyDataSetChanged()
         }
     }
 

--- a/app/src/main/java/com/example/snack4diet/viewModel/NutrientsViewModel.kt
+++ b/app/src/main/java/com/example/snack4diet/viewModel/NutrientsViewModel.kt
@@ -1,8 +1,28 @@
 package com.example.snack4diet.viewModel
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.snack4diet.api.Macronutrients
 
 class NutrientsViewModel: ViewModel() {
-    val nutrients = mutableListOf<Macronutrients>()
+    private val nutrients = mutableListOf(
+        Macronutrients("음식1",325, 24,32,25, false),
+        Macronutrients("음식2",325, 24,32,25, false),
+        Macronutrients("음식3",325, 24,32,25, false),
+        Macronutrients("음식4",325, 24,32,25, false)
+    )
+
+    val nutrientsLiveData: LiveData<MutableList<Macronutrients>>
+        get() = MutableLiveData(nutrients)
+
+    fun resisterBookmark (nutrient: Macronutrients) {
+        if (!nutrient.isBookmark) {
+            nutrient.isBookmark = true
+        }
+    }
+
+    fun deleteBookmark (nutrient: Macronutrients) {
+        nutrient.isBookmark = false
+    }
 }

--- a/app/src/main/res/layout/fragment_bookmark.xml
+++ b/app/src/main/res/layout/fragment_bookmark.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_marginHorizontal="10dp"
+    android:layout_marginTop="10dp"
     android:orientation="vertical">
 
     <LinearLayout

--- a/app/src/main/res/layout/fragment_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet.xml
@@ -71,7 +71,8 @@
             android:layout_height="wrap_content"
             android:text="칼로리"
             android:textSize="22sp"
-            android:fontFamily="@font/pretendard"
+            android:textColor="@color/black"
+            android:fontFamily="@font/pretendard_bold"
             android:layout_gravity="center"/>
 
         <Space
@@ -120,7 +121,8 @@
             android:layout_height="wrap_content"
             android:text="탄수화물"
             android:textSize="22sp"
-            android:fontFamily="@font/pretendard"
+            android:textColor="@color/black"
+            android:fontFamily="@font/pretendard_bold"
             android:layout_gravity="center"/>
 
         <Space
@@ -169,7 +171,8 @@
             android:layout_height="wrap_content"
             android:text="  - 당류"
             android:textSize="22sp"
-            android:fontFamily="@font/pretendard"
+            android:textColor="@color/black"
+            android:fontFamily="@font/pretendard_bold"
             android:layout_gravity="center"/>
 
         <Space
@@ -218,7 +221,8 @@
             android:layout_height="wrap_content"
             android:text="단백질"
             android:textSize="22sp"
-            android:fontFamily="@font/pretendard"
+            android:textColor="@color/black"
+            android:fontFamily="@font/pretendard_bold"
             android:layout_gravity="center"/>
 
         <Space
@@ -267,7 +271,8 @@
             android:layout_height="wrap_content"
             android:text="지방"
             android:textSize="22sp"
-            android:fontFamily="@font/pretendard"
+            android:textColor="@color/black"
+            android:fontFamily="@font/pretendard_bold"
             android:layout_gravity="center"/>
 
         <Space
@@ -316,7 +321,8 @@
             android:layout_height="wrap_content"
             android:text="  - 포화지방"
             android:textSize="22sp"
-            android:fontFamily="@font/pretendard"
+            android:textColor="@color/black"
+            android:fontFamily="@font/pretendard_bold"
             android:layout_gravity="center"/>
 
         <Space
@@ -365,7 +371,8 @@
             android:layout_height="wrap_content"
             android:text="  - 불포화지방"
             android:textSize="22sp"
-            android:fontFamily="@font/pretendard"
+            android:textColor="@color/black"
+            android:fontFamily="@font/pretendard_bold"
             android:layout_gravity="center"/>
 
         <Space
@@ -414,7 +421,8 @@
             android:layout_height="wrap_content"
             android:text="  - 트랜스지방"
             android:textSize="22sp"
-            android:fontFamily="@font/pretendard"
+            android:textColor="@color/black"
+            android:fontFamily="@font/pretendard_bold"
             android:layout_gravity="center"/>
 
         <Space
@@ -464,7 +472,8 @@
             android:layout_height="wrap_content"
             android:text="나트륨"
             android:textSize="22sp"
-            android:fontFamily="@font/pretendard"
+            android:textColor="@color/black"
+            android:fontFamily="@font/pretendard_bold"
             android:layout_gravity="center"/>
 
         <Space

--- a/app/src/main/res/layout/item_bookmark.xml
+++ b/app/src/main/res/layout/item_bookmark.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="420sp"
     android:layout_height="190sp"
@@ -34,6 +34,7 @@
                 android:layout_weight="1"/>
 
             <ImageButton
+                android:id="@+id/btnEdit"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="10dp"
@@ -42,7 +43,7 @@
                 android:layout_gravity="center"/>
 
             <ImageButton
-                android:id="@+id/btnMagnifier"
+                android:id="@+id/btnDelete"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
@@ -288,4 +289,4 @@
 
     </LinearLayout>
 
-</FrameLayout>
+</LinearLayout>


### PR DESCRIPTION
close #9 

#### 변경사항
- mainActivity에서 뷰모델을 선언 후 homeFramgment와 bookmarkFragment에서 같은 뷰모델 객체를 공유
- 위의 뷰모델과 라이브 데이터를 활용하여 두 프래그먼트에서 데이터 공유
- bookmarkFragment에서는 isBookmark 변수의 값을 기준으로 즐겨찾기에 등록된 아이템만을 렌더링

#### 필요구현사항
- bookmarkFragment에서 삭제 버튼 클릭 시 해당 아이템을 라이브 데이터 리스트에서 찾고 삭제하는 기능 구현 필요