### PR TITLE
✨ Feat: 메인 페이지 상단 달력 구현 (#10)

### DIFF
--- a/app/src/main/java/com/example/snack4diet/api/ApiModels.kt
+++ b/app/src/main/java/com/example/snack4diet/api/ApiModels.kt
@@ -23,3 +23,9 @@ data class NutritionItem(
     val consumedAmount: Int,
     val targetAmount: Int
 )
+
+data class DayWithWeekday(
+    val day: Int,
+    val weekday: String,
+    var isClicked: Boolean = false
+)

--- a/app/src/main/java/com/example/snack4diet/calendar/CalendarAdapter.kt
+++ b/app/src/main/java/com/example/snack4diet/calendar/CalendarAdapter.kt
@@ -1,0 +1,53 @@
+package com.example.snack4diet.calendar
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import com.example.snack4diet.R
+import com.example.snack4diet.api.DayWithWeekday
+import com.example.snack4diet.databinding.ItemDateBinding
+import com.example.snack4diet.home.HomeFragment
+
+class CalendarAdapter(
+    private val dayList: MutableList<DayWithWeekday>,
+    private var initialPosition: Int,
+    private val context: Context,
+    private val itemClickListener: HomeFragment.ItemClickListener): RecyclerView.Adapter<CalendarAdapter.ViewHolder>() {
+
+    inner class ViewHolder(binding: ItemDateBinding): RecyclerView.ViewHolder(binding.root) {
+        val itemLayout = binding.itemLayout
+        val day = binding.day
+        val weekday = binding.weekday
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemDateBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = dayList[position]
+
+        holder.day.text = item.day.toString()
+        holder.weekday.text = item.weekday
+
+        if (item.isClicked) {
+            holder.day.setTextColor(ContextCompat.getColor(context, R.color.orange))
+            holder.weekday.setTextColor(ContextCompat.getColor(context, R.color.orange))
+        } else {
+            holder.day.setTextColor(ContextCompat.getColor(context, R.color.black))
+            holder.weekday.setTextColor(ContextCompat.getColor(context, R.color.black))
+        }
+
+        holder.itemLayout.setOnClickListener {
+            itemClickListener.onItemClick(position)
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return dayList.size
+    }
+}

--- a/app/src/main/res/drawable/ic_btn_left.xml
+++ b/app/src/main/res/drawable/ic_btn_left.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="21dp"
+    android:viewportWidth="12"
+    android:viewportHeight="21">
+  <path
+      android:pathData="M11.313,1.115C10.802,0.604 9.979,0.604 9.469,1.115L0.813,9.771C0.406,10.177 0.406,10.833 0.813,11.24L9.469,19.896C9.979,20.406 10.802,20.406 11.313,19.896C11.823,19.386 11.823,18.563 11.313,18.052L3.771,10.5L11.323,2.948C11.823,2.448 11.823,1.615 11.313,1.115Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/ic_btn_right.xml
+++ b/app/src/main/res/drawable/ic_btn_right.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="21dp"
+    android:viewportWidth="12"
+    android:viewportHeight="21">
+  <path
+      android:pathData="M0.688,19.885C1.198,20.396 2.021,20.396 2.531,19.885L11.188,11.229C11.594,10.823 11.594,10.167 11.188,9.76L2.531,1.104C2.021,0.594 1.198,0.594 0.688,1.104C0.177,1.615 0.177,2.437 0.688,2.948L8.229,10.5L0.677,18.052C0.177,18.552 0.177,19.385 0.688,19.885Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -21,22 +21,66 @@
             android:layout_height="0dp"
             android:layout_weight="1.5"/>
 
-        <FrameLayout
-            android:layout_width="140dp"
-            android:layout_height="40dp"
-            android:background="@drawable/round_frame_red_20"
-            android:layout_gravity="center">
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/date"
+            <ImageButton
+                android:id="@+id/btnLeft"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="09월/12일 (화)"
-                android:textSize="20sp"
-                android:textColor="@color/white"
+                android:layout_marginEnd="10dp"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_btn_left"
                 android:layout_gravity="center"/>
 
-        </FrameLayout>
+            <LinearLayout
+                android:layout_width="120dp"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/year"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="2023"
+                    android:textSize="26sp"
+                    android:textColor="@color/black"
+                    android:fontFamily="@font/pretendard_bold"
+                    android:layout_gravity="center"/>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="."
+                    android:textColor="@color/black"
+                    android:textSize="26sp"
+                    android:layout_gravity="center"
+                    android:fontFamily="@font/pretendard_bold"/>
+
+                <TextView
+                    android:id="@+id/month"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="17"
+                    android:textSize="26sp"
+                    android:textColor="@color/black"
+                    android:fontFamily="@font/pretendard_bold"
+                    android:layout_gravity="center"/>
+            </LinearLayout>
+
+            <ImageButton
+                android:id="@+id/btnRight"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_btn_right"
+                android:layout_gravity="center"/>
+
+        </LinearLayout>
 
         <Space
             android:layout_width="0dp"

--- a/app/src/main/res/layout/item_date.xml
+++ b/app/src/main/res/layout/item_date.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
+    android:id="@+id/itemLayout"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="69dp"
     android:layout_height="69dp"
@@ -7,12 +8,13 @@
 
     <TextView
         android:id="@+id/day"
-        android:layout_width="wrap_content"
+        android:layout_width="40dp"
         android:layout_height="wrap_content"
         android:text="1"
         android:textSize="28sp"
         android:fontFamily="@font/pretendard"
         android:layout_gravity="center"
+        android:gravity="center"
         android:textColor="@color/black"
         />
 
@@ -21,7 +23,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="월"
-        android:textSize="12sp"
+        android:textSize="14sp"
         android:fontFamily="@font/pretendard"
         android:layout_gravity="center"
         android:textColor="@color/black"


### PR DESCRIPTION
close #19 

- 유저가 화면에 처음 진입했을 때는 오늘 날짜를 기본으로 설정
- 달력 상단에 화살표 버튼을 통해 한달 간격으로 날짜 변경
- 화살표를 통해 날짜를 변경하는 경우 해당 달력의 초기 위치는 1일로 설정
- 유저가 달력의 날짜 클릭 시 클릭된 날짜의 텍스트를 주황색으로 변경 (메인 화면 진입 또는 새로고침 진행 시 오늘의 날짜가 주황색)